### PR TITLE
Disable request timeout by default (but accept as option if desired)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub fn run(cli_args: &CliArgs, config: &Config) -> anyhow::Result<String> {
             cli_args.input.as_str(),
             cli_args.pre_prompt,
             config.openai_api_key.as_str(),
+            cli_args.timeout,
         );
         spinner.stop();
         let response = response?;
@@ -39,6 +40,7 @@ pub fn run(cli_args: &CliArgs, config: &Config) -> anyhow::Result<String> {
             cli_args.input.as_str(),
             cli_args.pre_prompt,
             config.openai_api_key.as_str(),
+            cli_args.timeout,
         );
         let mut response = response?;
         if cli_args.pre_prompt == openai::PrePrompt::ShellScript {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ Usage: gpt <your_question>
 Options:
   -s  --shell           Ask ChatGPT for a shell script                                                  [boolean=false]
       --raw             Only output the script, no spinner or interactive prompt                        [boolean=false]
+      --timeout         Timeout in seconds for ChatGPT response (default = no timeout)                  [number]
       --clear-config    Remove local config, including the OpenAI API key at `~/.config/shell-gpt-rs`   [boolean]
   -h, --help            Show help                                                                       [boolean]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,14 +9,14 @@ fn main() {
         println!("
 Ask ChatGPT for a shell script, code, or anything, directly from your terminal 🤖🧠👨‍💻
 
-Usage: gpt <your_question>
+Usage: gpt [options] <your_question>
 
 Options:
-  -s  --shell           Ask ChatGPT for a shell script                                                  [boolean=false]
-      --raw             Only output the script, no spinner or interactive prompt                        [boolean=false]
-      --timeout         Timeout in seconds for ChatGPT response (default = no timeout)                  [number]
-      --clear-config    Remove local config, including the OpenAI API key at `~/.config/shell-gpt-rs`   [boolean]
-  -h, --help            Show help                                                                       [boolean]
+  -s  --shell            Ask ChatGPT for a shell script                                                 [boolean=false]
+      --raw              Only output the script, no spinner or interactive prompt                       [boolean=false]
+      --timeout SECONDS  Timeout in seconds for ChatGPT response (default = no timeout)                 [number]
+      --clear-config     Remove local config, including the OpenAI API key at `~/.config/shell-gpt-rs`  [boolean]
+  -h, --help             Show help                                                                      [boolean]
 
 Examples:
   gpt is the earth flat?


### PR DESCRIPTION
I noticed that on a few occasions I'd hit the [default 30-second timeout that `reqwest` has on the blocking client](https://docs.rs/reqwest/latest/reqwest/blocking/struct.ClientBuilder.html#method.timeout). This change disables the timeout by default, but allows `--timeout <seconds>` as an option for use cases where that might be required.

My assumption was that most of the time someone is running the command interactively, and they probably want to make sure to get the response that ChatGPT spent API resources on generating. However, it would also be entirely reasonable to default to the original 30-second timeout instead, and allow something like  `--timeout 0` to disable it, if that's more desirable for backwards compatibility.